### PR TITLE
feat: add gha-runner-scale-set-controller ArgoCD application

### DIFF
--- a/k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/application.yaml
+++ b/k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/application.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gha-runner-scale-set-controller
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - ServerSideApply=true
+  destination:
+    name: in-cluster
+    namespace: arc-systems
+  sources:
+    - repoURL: 'https://github.com/sebastiaankok/k8s-homelab.git'
+      targetRevision: main
+      ref: values
+      path: "k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/"
+      directory:
+        exclude: '{application.yaml,values.yaml}'
+    - chart: gha-runner-scale-set-controller
+      repoURL: 'oci://ghcr.io/actions/actions-runner-controller-charts'
+      targetRevision: 0.9.3
+      helm:
+        releaseName: "gha-runner-scale-set-controller"
+        valueFiles:
+          - $values/k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/values.yaml

--- a/k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/namespace.yaml
+++ b/k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: arc-systems
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"

--- a/k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/values.yaml
+++ b/k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/values.yaml
@@ -1,0 +1,26 @@
+---
+fullnameOverride: actions-runner-controller
+flags:
+  logLevel: info
+  logFormat: text
+  runnerMaxConcurrentReconciles: 5
+  updateStrategy: immediate
+
+replicaCount: 1
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 256Mi
+
+podSecurityContext:
+  fsGroup: 1030
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1030

--- a/k8s/scripts/validate.sh
+++ b/k8s/scripts/validate.sh
@@ -221,28 +221,34 @@ layer3_helm() {
         continue
       fi
 
-      local repo_name
-      repo_name=$(echo "$repo_url" | sed -E 's|https?://||' | sed -E 's/[^a-zA-Z0-9.-]/_/g')
-
-      local found=false
-      for r in "${repos[@]}"; do
-        if [[ "$r" == "$repo_url" ]]; then
-          found=true
-          break
-        fi
-      done
-
-      if [[ "$found" == "false" ]]; then
-        log_info "Adding helm repo: $repo_name ($repo_url)"
-        helm repo add "$repo_name" "$repo_url" > /dev/null 2>&1 || true
-        repos+=("$repo_url")
-      fi
-
       local release_name
       release_name=$(yq -r '.spec.sources[1].helm.releaseName // .metadata.name' "$app_yaml")
 
+      local chart_ref
+      if [[ "$repo_url" == oci://* ]]; then
+        chart_ref="${repo_url}/${chart}"
+      else
+        local repo_name
+        repo_name=$(echo "$repo_url" | sed -E 's|https?://||' | sed -E 's/[^a-zA-Z0-9.-]/_/g')
+
+        local found=false
+        for r in "${repos[@]}"; do
+          if [[ "$r" == "$repo_url" ]]; then
+            found=true
+            break
+          fi
+        done
+
+        if [[ "$found" == "false" ]]; then
+          log_info "Adding helm repo: $repo_name ($repo_url)"
+          helm repo add "$repo_name" "$repo_url" > /dev/null 2>&1 || true
+          repos+=("$repo_url")
+        fi
+        chart_ref="$repo_name/$chart"
+      fi
+
       local helm_args=(
-        "$release_name" "$repo_name/$chart"
+        "$release_name" "$chart_ref"
         --version "$version"
         --namespace default
       )


### PR DESCRIPTION
Closes #450

Adds the GitHub Actions Runner Scale Set Controller as a system-level ArgoCD application in the `arc-systems` namespace.

## Changes

- `k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/application.yaml`
- `k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/values.yaml`
- `k8s/k3s-home/argocd/system/gha-runner-scale-set-controller/namespace.yaml`
- `k8s/scripts/validate.sh` — add OCI Helm chart support

Generated with [Claude Code](https://claude.ai/code)