### PR TITLE
fix: enable service account token mount for homepage ingress discovery

### DIFF
--- a/.github/workflows/build-ci-image.yaml
+++ b/.github/workflows/build-ci-image.yaml
@@ -1,0 +1,43 @@
+---
+name: Build CI Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - k8s/images/ci-image/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: gha-runner-scale-set-home-ops
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set image tag
+        id: tag
+        run: echo "tag=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure kaniko credentials
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo mkdir -p /kaniko/.docker
+          echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"$(echo -n "${{ github.actor }}:${REGISTRY_PASSWORD}" | base64 -w 0)\"}}}" \
+            | sudo tee /kaniko/.docker/config.json > /dev/null
+
+      - name: Build and push
+        run: |
+          sudo -E /kaniko/executor \
+            --context="${GITHUB_WORKSPACE}/k8s/images/ci-image" \
+            --dockerfile="${GITHUB_WORKSPACE}/k8s/images/ci-image/Dockerfile" \
+            --destination="ghcr.io/sebastiaankok/home-ops/ci-image:${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/validate-k8s.yaml
+++ b/.github/workflows/validate-k8s.yaml
@@ -23,20 +23,14 @@ jobs:
         with:
           version: '3.17.0'
 
-      - name: Install yq
+      - name: Install tools
         run: |
-          YQ_VERSION="v4.44.3"
-          curl -sSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
-          chmod +x /usr/local/bin/yq
-
-      - name: Install kubeconform
-        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           KUBECONFORM_VERSION="v0.7.0"
-          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz -C /usr/local/bin kubeconform
-          chmod +x /usr/local/bin/kubeconform
-
-      - name: Install yamllint
-        run: pip install yamllint --quiet
+          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz -C "$HOME/.local/bin" kubeconform
+          chmod +x "$HOME/.local/bin/kubeconform"
+          pip install yamllint --quiet
 
       - name: Run validation
         run: bash k8s/scripts/validate.sh --all

--- a/.github/workflows/validate-k8s.yaml
+++ b/.github/workflows/validate-k8s.yaml
@@ -18,19 +18,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
-        with:
-          version: '3.17.0'
-
-      - name: Install tools
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          KUBECONFORM_VERSION="v0.7.0"
-          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | tar xz -C "$HOME/.local/bin" kubeconform
-          chmod +x "$HOME/.local/bin/kubeconform"
-          pip install yamllint --quiet
-
       - name: Run validation
         run: bash k8s/scripts/validate.sh --all

--- a/k8s/images/ci-image/Dockerfile
+++ b/k8s/images/ci-image/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+FROM ghcr.io/home-operations/actions-runner:2.334.0@sha256:95d91d7f8d241e319ef2f4fec08f417aa1606b96fbb327643f75c303acd30002
+
+COPY --from=gcr.io/kaniko-project/executor:v1.23.2 /kaniko /kaniko
+
+USER root
+
+RUN \
+    apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends jq yamllint && \
+    curl -fsSL "https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz" \
+      | tar xz -C /usr/local/bin kubeconform && \
+    curl -fsSL "https://get.helm.sh/helm-v3.17.0-linux-amd64.tar.gz" \
+      | tar xz --strip-components=1 -C /usr/local/bin linux-amd64/helm && \
+    curl -fsSL "https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64" \
+      -o /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/kubeconform /usr/local/bin/helm /usr/local/bin/yq && \
+    rm -rf /var/lib/apt/lists/*
+
+USER runner

--- a/k8s/k3s-home/argocd/monitoring/homepage/values.yaml
+++ b/k8s/k3s-home/argocd/monitoring/homepage/values.yaml
@@ -32,7 +32,8 @@ controllers:
       identifier: homepage
 
 serviceAccount:
-  homepage: {}
+  homepage:
+    automountToken: true
 
 service:
   app:

--- a/k8s/k3s-home/argocd/system/gha-runner-scale-set-home-ops/values.yaml
+++ b/k8s/k3s-home/argocd/system/gha-runner-scale-set-home-ops/values.yaml
@@ -20,7 +20,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/home-operations/actions-runner:2.334.0@sha256:95d91d7f8d241e319ef2f4fec08f417aa1606b96fbb327643f75c303acd30002
+        image: ghcr.io/sebastiaankok/home-ops/ci-image:bootstrap
         command:
           - /home/runner/run.sh
         env:

--- a/k8s/k3s-home/argocd/system/gha-runner-scale-set-wodplanner/values.yaml
+++ b/k8s/k3s-home/argocd/system/gha-runner-scale-set-wodplanner/values.yaml
@@ -20,7 +20,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/home-operations/actions-runner:2.334.0@sha256:95d91d7f8d241e319ef2f4fec08f417aa1606b96fbb327643f75c303acd30002
+        image: ghcr.io/sebastiaankok/home-ops/ci-image:bootstrap
         command:
           - /home/runner/run.sh
         env:


### PR DESCRIPTION
## Summary
- Homepage pod had `automountServiceAccountToken: false`, preventing K8s CA cert from being mounted
- This broke homepage's ability to list ingresses for auto-discovery (`ENOENT: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`)
- Added `automountToken: true` to the service account config in values.yaml