### PR TITLE
chore: add concurrency groups and permissions to workflows

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   opencode:
     if: |

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -32,7 +32,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/validate-k8s.yaml
+++ b/.github/workflows/validate-k8s.yaml
@@ -13,6 +13,13 @@ on:
       - 'k8s/**'
       - 'ci/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: gha-runner-scale-set-home-ops


### PR DESCRIPTION
## Summary

- Add concurrency group to `opencode.yml` (cancel-in-progress: false) to prevent duplicate runs stacking
- Set `renovate.yaml` cancel-in-progress to false so a new Renovate run doesn't kill an in-progress one
- Add concurrency group (cancel-in-progress: true) and permissions block to `validate-k8s.yaml` to align with best practices