### PR TITLE
fix: allow ingress from host identity for calibre gateway envoy

### DIFF
--- a/k8s/k3s-home/argocd/media/calibre-web-automated/networkpolicy.yaml
+++ b/k8s/k3s-home/argocd/media/calibre-web-automated/networkpolicy.yaml
@@ -6,9 +6,8 @@ metadata:
 spec:
   endpointSelector: {}
   ingress:
-    - fromEndpoints:
-        - matchLabels:
-            k8s:io.kubernetes.pod.namespace: kube-system
+    - fromEntities:
+        - host
     - fromEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: calibre


### PR DESCRIPTION
The Cilium Gateway API envoy runs on the host network, so its connections to calibre use the host identity (`reserved:host`), not a `kube-system` pod identity. Changed the ingress rule from `fromEndpoints: {namespace: kube-system}` to `fromEntities: [host]` to fix 503 upstream connection timeouts.