### PR TITLE
fix: use pod discovery for node-exporter and smartctl-exporter

### DIFF
--- a/k8s/k3s-home/argocd/monitoring/alloy/values.yaml
+++ b/k8s/k3s-home/argocd/monitoring/alloy/values.yaml
@@ -89,28 +89,33 @@ alloy:
       	scrape_interval = "30s"
       }
 
+      discovery.kubernetes "pods" {
+      	role = "pod"
+      }
+
       discovery.relabel "node_exporter" {
-      	targets = discovery.kubernetes.services.targets
+      	targets = discovery.kubernetes.pods.targets
 
       	rule {
-      		source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_service_name"]
-      		regex         = "monitoring;node-exporter-prometheus-node-exporter"
+      		source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      		regex         = "monitoring;prometheus-node-exporter"
       		action        = "keep"
+      	}
+
+      	rule {
+      		replacement  = "${1}:9100"
+      		source_labels = ["__meta_kubernetes_pod_ip"]
+      		target_label  = "__address__"
+      	}
+
+      	rule {
+      		source_labels = ["__meta_kubernetes_pod_node_name"]
+      		target_label  = "instance"
       	}
 
       	rule {
       		source_labels = ["__meta_kubernetes_namespace"]
       		target_label  = "namespace"
-      	}
-
-      	rule {
-      		source_labels = ["__meta_kubernetes_service_name"]
-      		target_label  = "service"
-      	}
-
-      	rule {
-      		target_label = "instance"
-      		replacement  = "b660-i5-13600"
       	}
       }
 
@@ -122,27 +127,28 @@ alloy:
       }
 
       discovery.relabel "smartctl_exporter" {
-      	targets = discovery.kubernetes.services.targets
+      	targets = discovery.kubernetes.pods.targets
 
       	rule {
-      		source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_service_name"]
+      		source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
       		regex         = "monitoring;smartctl-exporter"
       		action        = "keep"
       	}
 
       	rule {
+      		replacement  = "${1}:9633"
+      		source_labels = ["__meta_kubernetes_pod_ip"]
+      		target_label  = "__address__"
+      	}
+
+      	rule {
+      		source_labels = ["__meta_kubernetes_pod_node_name"]
+      		target_label  = "instance"
+      	}
+
+      	rule {
       		source_labels = ["__meta_kubernetes_namespace"]
       		target_label  = "namespace"
-      	}
-
-      	rule {
-      		source_labels = ["__meta_kubernetes_service_name"]
-      		target_label  = "service"
-      	}
-
-      	rule {
-      		target_label = "instance"
-      		replacement  = "b660-i5-13600"
       	}
       }
 


### PR DESCRIPTION
Switch from service-based to pod-based discovery for node-exporter and smartctl-exporter. Pod discovery adds explicit port in __address__ and uses pod_node_name as instance label.